### PR TITLE
解决 SSR 时网页源代码总是 todo 应用的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 node_modules/
+server-build/
+public/

--- a/build/webpack.config.base.js
+++ b/build/webpack.config.base.js
@@ -7,7 +7,7 @@ const isDev = process.env.NODE_ENV === 'development';
 
 const config = {
   target: 'web',
-  entry: path.join(__dirname, '../client/index.js'),
+  entry: path.join(__dirname, '../client/client-entry.js'),
   output: {
     filename: 'bundle.[hash:8].js',
     path: path.join(__dirname, '../dist'),

--- a/build/webpack.config.base.js
+++ b/build/webpack.config.base.js
@@ -10,7 +10,7 @@ const config = {
   entry: path.join(__dirname, '../client/client-entry.js'),
   output: {
     filename: 'bundle.[hash:8].js',
-    path: path.join(__dirname, '../dist'),
+    path: path.join(__dirname, '../public'),
     publicPath: '//127.0.0.1:8000/public/',
   },
   module: {

--- a/build/webpack.config.client.js
+++ b/build/webpack.config.client.js
@@ -38,7 +38,13 @@ const devServer = { // 支持热更新
   // 但是服务端没做配置的话，就会返回 404 cannot GET...
   // webpack 加上这个配置的话，那么就能匹配到打包文件的 index.html
   historyApiFallback: {
-    index: '/index.html',
+    // index: '/index.html',
+    rewrites: [
+      {
+        from: /.*/g,
+        to: '/public/index.html',
+      }
+    ]
   },
   hot: true, // 只重加载改动的组件
   // open: true, // 每次都会自动打开页面
@@ -101,7 +107,7 @@ if (isDev) {
     mode: 'production',
     entry: {
       // 将类库与第三方依赖单独打包成 vendor，因为如果跟业务代码混在一起，那么由于业务经常更新所以导致这些都无法长期缓存
-      app: path.join(__dirname, '../client/index.js'),
+      app: path.join(__dirname, '../client/client-entry.js'),
     },
     output: {
       // chunkhash 与 hash 的区别：

--- a/build/webpack.config.client.js
+++ b/build/webpack.config.client.js
@@ -114,6 +114,8 @@ if (isDev) {
       // chunkhash 如果你的文件不改变（类库），那么下次打包时的哈希值不会变；但是 hash 每次都会变
       // 所以第三方依赖与类库需要使用 chunkhash，否则单独打包就没意义了，也无法做长期缓存
       filename: '[name].[chunkhash:8].js',
+      // ssr 生产环境没有 devServer，所以这里还得做修改
+      publicPath: '/public/',
     },
     module: {
       rules: [

--- a/build/webpack.config.server.js
+++ b/build/webpack.config.server.js
@@ -20,6 +20,7 @@ const config = webpackMerge(baseConfig, {
     libraryTarget: 'commonjs2',
     filename: 'server-entry.js',
     path: path.join(__dirname, '../server-build'),
+    publicPath: '/public/',
   },
   // 纯前端渲染就需要把类库连同你的代码一起打包，因为浏览器没有 module 模块
   // 不要打包 vue, vuex, vue-router 到 node

--- a/client/app.vue
+++ b/client/app.vue
@@ -21,6 +21,9 @@ import { mapState, mapMutations, mapGetters, mapActions } from 'vuex'
 import Header from './layout/header.vue';
 // import Footer from './layout/footer.jsx';
 export default {
+  metaInfo: {
+    title: `haisheng's todo app`,
+  },
   components: {
     Header,
     // Footer,

--- a/client/client-entry.js
+++ b/client/client-entry.js
@@ -1,0 +1,7 @@
+import createApp from './create-app'
+
+const { app, router } = createApp()
+
+router.onReady(() => {
+  app.$mount('#root')
+})

--- a/client/create-app.js
+++ b/client/create-app.js
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Vuex from 'vuex'
 
+import VueMeta from 'vue-meta'
+
 import App from './app.vue'
 import createStore from './store/store'
 import createRouter from './config/router'
@@ -10,6 +12,7 @@ import './assets/styles/global.less'
 
 Vue.use(VueRouter)
 Vue.use(Vuex)
+Vue.use(VueMeta)
 
 export default () => {
   const router = createRouter()

--- a/client/layout/header.vue
+++ b/client/layout/header.vue
@@ -1,10 +1,10 @@
 <template>
-  <header :class="$style.mainHeader">
+  <header class="main-header">
     <h1>JTodo</h1>
   </header>
 </template>
 
-<style lang="less" module>
+<style lang="less" scoped>
   .main-header {
     text-align: center;
     h1 {

--- a/client/server-entry.js
+++ b/client/server-entry.js
@@ -10,6 +10,7 @@ export default context => {
       if (!matchedComponents.length) {
         reject(new Error('no component matched'))
       }
+      context.meta = app.$meta()
       resolve(app)
     })
   })

--- a/client/views/login/login.vue
+++ b/client/views/login/login.vue
@@ -4,6 +4,8 @@
 
 <script>
 export default {
-
+  metaInfo: { // 子组件的优先级比父组件高
+    title: `login page`,
+  },
 }
 </script>

--- a/client/views/todo/todo.vue
+++ b/client/views/todo/todo.vue
@@ -26,6 +26,9 @@
 import Item from './item.vue';
 import Tabs from './tabs.vue';
 export default {
+  metaInfo: { // 子组件的优先级比父组件高
+    title: `todo app`,
+  },
   components: {
     Item,
     Tabs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "http://registry.npm.taobao.org/deepmerge/download/deepmerge-3.2.0.tgz",
+      "integrity": "sha1-WO9GOlfAjTdlR/iGn9xbzulX9E4="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "http://registry.npm.taobao.org/default-gateway/download/default-gateway-4.2.0.tgz",
@@ -5817,6 +5822,11 @@
       "resolved": "http://registry.npm.taobao.org/lodash._reinterpolate/download/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "http://registry.npm.taobao.org/lodash.isplainobject/download/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "http://registry.npm.taobao.org/lodash.template/download/lodash.template-4.4.0.tgz",
@@ -5838,6 +5848,11 @@
       "version": "4.5.0",
       "resolved": "http://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "http://registry.npm.taobao.org/lodash.uniqueid/download/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
     },
     "loglevel": {
       "version": "1.6.1",
@@ -6392,8 +6407,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -9029,6 +9043,17 @@
         "loader-utils": "^1.1.0",
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
+      }
+    },
+    "vue-meta": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.taobao.org/vue-meta/download/vue-meta-1.6.0.tgz",
+      "integrity": "sha1-ibZk9gEaIH4JjoujudMuKcgZtl0=",
+      "requires": {
+        "deepmerge": "^3.2.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.uniqueid": "^4.0.1",
+        "object-assign": "^4.1.1"
       }
     },
     "vue-router": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ejs": "^2.6.1",
     "express": "^4.16.4",
     "vue": "^2.6.10",
+    "vue-meta": "^1.6.0",
     "vue-router": "^3.0.2",
     "vue-server-renderer": "^2.6.10",
     "vuex": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:client": "cross-env NODE_ENV=production webpack --config build/webpack.config.client.js",
-    "build": "npm run clean && npm run build:client",
+    "build:server": "cross-env NODE_ENV=production webpack --config build/webpack.config.server.js",
+    "build": "npm run clean && npm run build:client && npm run build:server",
     "practice": "cross-env NODE_ENV=development webpack-dev-server --config build/webpack.config.practice.js",
-    "clean": "rimraf dist",
+    "clean": "rimraf public && rimraf server-build",
     "lint": "eslint --ext .js --ext .jsx --ext .vue client/",
     "lint-fix": "eslint --fix --ext .js --ext .jsx --ext .vue client/",
     "dev:client": "cross-env NODE_ENV=development webpack-dev-server --config build/webpack.config.client.js",
     "dev:server": "nodemon server/server.js",
-    "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\""
+    "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
+    "start": "cross-env NODE_ENV=production node server/server.js"
   },
   "husky": {
     "hooks": {

--- a/server/routes/server-render.js
+++ b/server/routes/server-render.js
@@ -6,10 +6,12 @@ module.exports = async (req, res, renderer, template) => {
   try {
     // renderToString 会给 context 加入很多属性，例如 renderStyles
     const appString = await renderer.renderToString(context)
+    const { title } = context.meta.inject()
     const html = ejs.render(template, {
       appString,
       style: context.renderStyles(),
       scripts: context.renderScripts(),
+      title: title.text(),
     })
     res.send(html)
   } catch (err) {

--- a/server/routes/ssr.js
+++ b/server/routes/ssr.js
@@ -1,0 +1,23 @@
+const router = require('express').Router()
+const VueServerRenderer = require('vue-server-renderer')
+const path = require('path')
+const fs = require('fs')
+
+const serverRender = require('./server-render')
+
+const clientManifest = require('../../public/vue-ssr-client-manifest.json')
+const renderer = VueServerRenderer.createBundleRenderer(
+  path.join(__dirname, '../../server-build/vue-ssr-server-bundle.json'),
+  {
+    inject: false,
+    clientManifest,
+  }
+)
+
+const template = fs.readFileSync(path.join(__dirname, '../server-template.ejs'), 'utf-8')
+
+router.get('*', async (req, res) => {
+  await serverRender(req, res, renderer, template)
+})
+
+module.exports = router

--- a/server/routes/static.js
+++ b/server/routes/static.js
@@ -1,0 +1,8 @@
+const router = require('express').Router()
+const path = require('path')
+
+router.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '/../../public', req.path))
+})
+
+module.exports = router

--- a/server/server-template.ejs
+++ b/server/server-template.ejs
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>vue-ssr-learning</title>
+  <%- title %>
   <link rel="icon" href="favicon.ico">
   <%- style %>
 </head>

--- a/server/server.js
+++ b/server/server.js
@@ -2,8 +2,6 @@ const path = require('path')
 const express = require('express')
 const app = express()
 
-const pageRouter = require('./routes/dev-ssr')
-
 const isDev = process.env.NODE_ENV === 'development'
 
 app.use((req, res, next) => {
@@ -29,6 +27,9 @@ app.use((req, res, next) => {
   }
 })
 
+const pageRouter = isDev ? require('./routes/dev-ssr') : require('./routes/ssr')
+const staticRouter = require('./routes/static')
+app.use('/public', staticRouter)
 app.use('*', pageRouter)
 
 const HOST = process.env.HOST || '0.0.0.0'


### PR DESCRIPTION
如题，原因是 express 服务中 `server-render.js` 拿到的 `req.path` 总是 `'/'`，所以我替换成 `req.originalUrl` 就拿到完整的访问路径。那么给 `context.url` 赋值时便不会出错，从而 `router.js` 匹配到的 component 就正确了。